### PR TITLE
Modified initial width of search bar.

### DIFF
--- a/client/app/styles/displaymapfilter.css
+++ b/client/app/styles/displaymapfilter.css
@@ -149,6 +149,10 @@
   outline: none; 
 }
 
+.restaurant-name-filter {
+  min-width: 490px;
+}
+
 .suggestions-list {
   list-style-type: none; 
   padding: 0;


### PR DESCRIPTION
There is no more necessary to scroll horizontally when search restaurant by name.

Description
There is no more necessary to scroll horizontally when use restaurant by name filter.


What's in this change?
Modified min-width of search bar in css file to 490px.


Testing changes
Tested locally.
